### PR TITLE
docs: use absolute image paths in README [LAC-1896]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Don't Panic.** This is an AI-powered, entirely generative website version of *The Hitchhiker's Guide to the Galaxy*.
 
-![Homepage hero — DON'T PANIC](docs/images/screenshot-hero.png)
+![Homepage hero — DON'T PANIC](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-hero.png)
 
 Every page is born when you ask for it — just like the original Guide (minus the sarcasm filter). It's not a static site. It's not a wiki. It's the Guide, reimagined by a mildly confused neural network with access to far too much cosmic trivia.
 
@@ -19,11 +19,11 @@ Curious about towels? It's got you covered.
 
 | Homepage | Popular Entries |
 |----------|-----------------|
-| ![Homepage with recent entries](docs/images/screenshot-homepage.png) | ![Popular entries page](docs/images/screenshot-popular.png) |
+| ![Homepage with recent entries](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-homepage.png) | ![Popular entries page](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-popular.png) |
 
 | Entry Detail | Mobile |
 |--------------|--------|
-| ![Entry detail view](docs/images/screenshot-entry.png) | ![Mobile view](docs/images/screenshot-mobile.png) |
+| ![Entry detail view](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-entry.png) | ![Mobile view](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-mobile.png) |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Don't Panic.** This is an AI-powered, entirely generative website version of *The Hitchhiker's Guide to the Galaxy*.
 
-![Homepage hero — DON'T PANIC](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-hero.png)
+![Homepage hero — DON'T PANIC](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/HEAD/docs/images/screenshot-hero.png)
 
 Every page is born when you ask for it — just like the original Guide (minus the sarcasm filter). It's not a static site. It's not a wiki. It's the Guide, reimagined by a mildly confused neural network with access to far too much cosmic trivia.
 
@@ -19,11 +19,16 @@ Curious about towels? It's got you covered.
 
 | Homepage | Popular Entries |
 |----------|-----------------|
-| ![Homepage with recent entries](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-homepage.png) | ![Popular entries page](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-popular.png) |
+| ![Homepage with recent entries][img-homepage] | ![Popular entries page][img-popular] |
 
 | Entry Detail | Mobile |
 |--------------|--------|
-| ![Entry detail view](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-entry.png) | ![Mobile view](https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/main/docs/images/screenshot-mobile.png) |
+| ![Entry detail view][img-entry] | ![Mobile view][img-mobile] |
+
+[img-homepage]: https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/HEAD/docs/images/screenshot-homepage.png
+[img-popular]: https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/HEAD/docs/images/screenshot-popular.png
+[img-entry]: https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/HEAD/docs/images/screenshot-entry.png
+[img-mobile]: https://raw.githubusercontent.com/lacymorrow/hitchhikersgalaxy.guide/HEAD/docs/images/screenshot-mobile.png
 
 ## Features
 


### PR DESCRIPTION
Convert relative image paths to raw.githubusercontent.com URLs so images render when README is embedded on external sites (lacymorrow.com). LAC-1896.