### PR TITLE
fix: use runtime OPENAI_API_KEY check instead of build-time feature flag

### DIFF
--- a/src/lib/open-ai.ts
+++ b/src/lib/open-ai.ts
@@ -1,10 +1,11 @@
 import OpenAI from "openai";
 import { env } from "@/env";
 
-// Initialize OpenAI client only if the feature is enabled and the API key is present
-export const openai =
-  env.NEXT_PUBLIC_FEATURE_OPENAI_ENABLED && env?.OPENAI_API_KEY
-    ? new OpenAI({
-        apiKey: env?.OPENAI_API_KEY,
-      })
-    : null; // Set to null if disabled or key is missing
+// Initialize OpenAI client only if the API key is present at runtime
+// Note: avoid gating on NEXT_PUBLIC_FEATURE_OPENAI_ENABLED (build-time baked) —
+// the key presence alone is the correct runtime guard.
+export const openai = env?.OPENAI_API_KEY
+  ? new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+    })
+  : null;


### PR DESCRIPTION
Fixes LAC-1947 — openai null because NEXT_PUBLIC_FEATURE_OPENAI_ENABLED was baked false at build time. Now checks OPENAI_API_KEY directly at runtime.