### PR TITLE
fix(ci): upgrade GitHub Actions to v6 for Node 24

### DIFF
--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -21,10 +21,10 @@ jobs:
         run: |
           echo 'Skipping Auto Fix Issues: OPENAI_API_KEY not set'
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo 'Skipping Claude Code Review: CLAUDE_CODE_OAUTH_TOKEN not set'
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo 'Skipping Claude PR Assistant: Claude OAuth secrets not set'
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all branches
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/init-upstream.yml
+++ b/.github/workflows/init-upstream.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -17,7 +17,7 @@ jobs:
           bun-version: 1.1.34
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -40,7 +40,7 @@ jobs:
         run: bun run audit:lh:loop -- http://localhost:3000/
 
       - name: Upload Lighthouse Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-reports
           path: .lighthouse

--- a/.github/workflows/run-codex.yml
+++ b/.github/workflows/run-codex.yml
@@ -26,10 +26,10 @@ jobs:
         run: |
           echo 'Skipping Run Codex: OPENAI_API_KEY not set'
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for merging
           token: ${{ secrets.GITHUB_TOKEN }} # Use default token for checkout


### PR DESCRIPTION
Upgrades GitHub Actions to v6 for the Node 20→24 migration (deadline: June 16, 2026).

Updated 8 workflow files:
- `actions/checkout`: v4 → v6
- `actions/setup-node`: v4 → v6
- `actions/upload-artifact`: v4 → v6